### PR TITLE
fix: CLI bin path

### DIFF
--- a/.changeset/calm-clouds-roll.md
+++ b/.changeset/calm-clouds-roll.md
@@ -1,0 +1,5 @@
+---
+'@base-org/build-onchain-apps': patch
+---
+
+fix: bin path pointing to wrong folder.

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "includedScripts": []
   },
   "type": "commonjs",
-  "main": "./src/index.js",
-  "typings": "./src/index.d.ts",
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
   "bin": {
-    "build-onchain-apps": "./src/index.js"
+    "build-onchain-apps": "./dist/src/index.js"
   }
 }


### PR DESCRIPTION
**What changed? Why?**
- CLI bin path should point to dist folder.

**Notes to reviewers**


**How has it been tested?**
