### PR TITLE
feat: moved templated created inside /apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,56 @@
 # [Build Onchain Apps](https://github.com/base-org/build-onchain-apps)
 
-> The easier way to build onchain apps.
+> The easier way to build onchain applications.
 
-<br />
+Building an Onchain Application can feel overwhelming due to the many libraries, best practices, and choices developers and entrepreneurs must make.
 
-Building an Onchain Application can feel overwhelming due to the many libraries, best practices, and choices developers and entrepreneurs must make. **Build Onchain Apps** as a library focuses on automating and simplifying the creation of new Onchain Apps and enhancing existing ones.
+**Build Onchain Apps** takes an opinionated approach to simplify and automate your experience. So, if you are either a hackathon participant and/or an ambitious entrepreneur aiming to establish the next successful company, this is built with you in mind. 💙
 
-We just started; stay tuned for more to come!!! ☕️ 🔵
+Out of the box 🧰 🧙 ✨
+
+- Web2 building blocks: [Next.js](https://nextjs.org/) + [Tailwind CSS](https://tailwindcss.com/) + [Radix UI](https://www.radix-ui.com/) 🟡
+- Onchain building blocs: [RainbowKit](https://www.rainbowkit.com/) + [wagmi](https://wagmi.sh/) + [Viem](https://viem.sh/) 🔵
+- Support EOA Wallet integration 👛
+- Linting and Prettier 💅
+- _Support Progressive Web Apps (Coming Soon)_
+- _Client Analytics (Coming Soon)_
+- _Tests Suite (Coming Soon)_
+- _Web Vitals optimization (Coming Soon)_
+- _In-depth step by step documentation (Coming Soon)_
+- _We just started; stay tuned for more to come!!! ☕️_
+
+<br >
 
 ## Getting Started
 
-```sh
-npx @base-org/build-onchain-apps@latest create <TEMPLATE_APP>
+```bash
+## Kick off your Onchain App
+npx @base-org/build-onchain-apps@latest create
 ```
 
 <p align='center'>
-<img src='https://images.ctfassets.net/c5bd0wqjc7v0/3dFiAAcNU2DauF5zvakbA0/cc4bcc4621a12da40e6248b41e450844/cli.gif' width='600' alt='npm start'>
+  <img src='https://images.ctfassets.net/c5bd0wqjc7v0/3dFiAAcNU2DauF5zvakbA0/cc4bcc4621a12da40e6248b41e450844/cli.gif' 
+  width='600' alt='Build Onchain Apps'>
 </p>
 
-If you've previously installed `@base-org/build-onchain-apps` globally via `npm install -g @base-org/build-onchain-apps`, we recommend you uninstall the package using `npm uninstall -g @base-org/build-onchain-apps` or `yarn global remove @base-org/build-onchain-apps` to ensure that npx always uses the latest version.
+#### When using Build Onchain Apps remember
 
-_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
+To remove global installation via `npm uninstall -g @base-org/build-onchain-apps` or `yarn global remove @base-org/build-onchain-apps` to ensure that npx always uses the latest version.
+
+[npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f)
 
 <br >
 
 ## Contributing ☕️ 🔵
 
-The main purpose of this repository is to continue evolving Build Onchain Apps, making it better and easier to use. Development of React happens in the open on GitHub, and we are grateful to the community for contributing bugfixes and improvements. Read below to learn how you can take part in improving Build Onchain Apps.
-
+The main purpose of this repository is to continue evolving Build Onchain Apps, making it better and easier to use. Development of Build Onchain Apps happens in the open on GitHub, and we are grateful to the community for contributing bugfixes and improvements. Read below to learn how you can take part in improving Build Onchain Apps.
 
 ### [Code of Conduct](CODE_OF_CONDUCT.md).
+
 Build Onchain Apps has adopted a Code of Conduct that we expect project participants to adhere to. Please read the full text so that you can understand what actions will and will not be tolerated.
 
-
 ### [Contributing Guide](CONTRIBUTING.md).
+
 Read our contributing guide to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Build Onchain Apps.
 
 ### Develop

--- a/src/create.ts
+++ b/src/create.ts
@@ -11,8 +11,11 @@ import {
 } from './utils/templates';
 import { isRootDirWriteable, getProjectDir } from './utils/dir';
 
+// Default location for all Onchain Applications
+const APPS_DIR = 'apps/';
+
 /**
- * Responsible for copying the 
+ * Responsible for copying the
  * onchain template and create new project.
  */
 export const createProject = async (templateName: string) => {
@@ -71,7 +74,7 @@ export const createProject = async (templateName: string) => {
   ]);
 
   const appName = appNameAnswer.appName;
-  const projectDir = getProjectDir(appName);
+  const projectDir = getProjectDir(APPS_DIR + appName);
 
   if (fs.existsSync(projectDir)) {
     console.error(

--- a/src/utils/dir.ts
+++ b/src/utils/dir.ts
@@ -20,6 +20,6 @@ export async function isRootDirWriteable() {
   return isWriteable(ROOT_DIR);
 }
 
-export function getProjectDir(appName: string) {
-  return path.join(ROOT_DIR, appName);
+export function getProjectDir(appDirLocation: string) {
+  return path.join(ROOT_DIR, appDirLocation);
 }


### PR DESCRIPTION
**What changed? Why?**
Kept polishing the README, also made `/apps` as the location where templates are generated. This will make a bit more clean to generate different type of apps and have them all in the same folder.

**Notes to reviewers**


**How has it been tested?**
